### PR TITLE
[style] remove .md-content min-height override

### DIFF
--- a/overrides/assets/stylesheets/extra.css
+++ b/overrides/assets/stylesheets/extra.css
@@ -160,11 +160,6 @@ div.md-nav__link--index {
     }
 }
 
-/* override md-content min-height */
-.md-content {
-    min-height: 100vh;
-}
-
 /* override md-banner*/
 .md-banner {
     background: #0091eb;


### PR DESCRIPTION
Before (current):
![image](https://github.com/user-attachments/assets/1c754978-aedb-47e2-a5e4-84ad92ee9f2a)
What's the point of making short pages so long?

I believe it's an old override that doesn't take header and footer height into account anymore, so that the whole page min-height isn't 100vh (as expected), but rather becomes: 100vh + header height + footer height, which adds an unnecessary scroll.

After (this MR):
![image](https://github.com/user-attachments/assets/60dc7096-a8dd-4890-ba60-cfaf6a8ff503)
