### PR TITLE
[Animation] Update & reword "How to play or edit animations" to be a bit more specific

### DIFF
--- a/docs/zengin/anims/tutorials/standalone_animation.md
+++ b/docs/zengin/anims/tutorials/standalone_animation.md
@@ -10,7 +10,7 @@ Let us start with the easiest animation - a very simple gesturing animation.
 Firstly we have to have the animation source files ready. Best way to decompile them is using [Gothic Sourcer](https://worldofplayers.ru/threads/41942/). In GothicSourcer you choose **Tools > Decompiler models > Dynamic (MDS or MSB)** and choose an MDS file of your choice - `Humans.mds` in our case and then click the decompile button.
 
 ## Animating
-Open Blender, **File > Import > Kerrax ASCII model (.asc)**, navigate to the folder with your decompiled animation files and select `HUM_BODY_NAKED0.ASC`. This file contains the skeleton and skin model for human NPCs.
+Open Blender, **File > Import > Shoun's ASCII Model Importer (.asc)**, navigate to the folder with your decompiled animation files and select `HUM_BODY_NAKED0.ASC`. This file contains the skeleton and skin model for human NPCs.
 
 !!! tip "What bone hierarchy is this model using?"  
     If you open the `.mds` file, you can see a command `meshAndTree` that specifies what model contains the skeleton. And there lies our answer:

--- a/docs/zengin/anims/tutorials/standalone_animation.md
+++ b/docs/zengin/anims/tutorials/standalone_animation.md
@@ -28,8 +28,8 @@ Click import and wait for the magic to happen.
 
 This video shows a freshly imported model with all default meshes.
 
-!!! note  
-    If we now want to play (or edit) existing animation, we can now load it on top of this. Just as before **File > Import > Kerrax ASCII model (.asc)** and select different animation file (or armor file), for example `Hum_SmokeHerb_Layer_M01.asc` for an animation file.  
+!!! How to play or edit animations  
+    If we now want to play (or edit) an existing animation, we can now load the animation file in .asc on top of our currently loaded model. Just as before, **File > Import > Shoun's ASCII Model importer (.asc)** and select the desired animation file (or armor file), for example `Hum_SmokeHerb_Layer_M01.asc`.  
 ![type:video](https://www.youtube.com/embed/FDicnSwhv0w)
 
 Gothic characters are modular and you can change their heads on the fly, even during gameplay as seen in this amazing video from my dear friend and colleague Fawkes - [Head changing](https://www.youtube.com/watch?v=2GBmpeyqKIA). Let's add a head so that we can see how the whole body will behave while we are animating. **File > Import > Kerrax ASCII model (.asc)**, navigate to your head model. You will have to decompile it like we did with the body itself. We will import `HUM_HEAD_PONY.ASC`. Please make sure to select the target bone for importing **Bip01 Head**, this will attach the head to the proper bone, just like the engine does it.

--- a/docs/zengin/anims/tutorials/standalone_animation.md
+++ b/docs/zengin/anims/tutorials/standalone_animation.md
@@ -28,7 +28,7 @@ Click import and wait for the magic to happen.
 
 This video shows a freshly imported model with all default meshes.
 
-!!! How to play or edit animations  
+!!! note "How to play or edit animations"
     If we now want to play (or edit) an existing animation, we can now load the animation file in .asc on top of our currently loaded model. Just as before, **File > Import > Shoun's ASCII Model importer (.asc)** and select the desired animation file (or armor file), for example `Hum_SmokeHerb_Layer_M01.asc`.  
 ![type:video](https://www.youtube.com/embed/FDicnSwhv0w)
 

--- a/docs/zengin/anims/tutorials/standalone_animation.md
+++ b/docs/zengin/anims/tutorials/standalone_animation.md
@@ -29,10 +29,10 @@ Click import and wait for the magic to happen.
 This video shows a freshly imported model with all default meshes.
 
 !!! note "How to play or edit animations"
-    If we now want to play (or edit) an existing animation, we can now load the animation file in .asc on top of our currently loaded model. Just as before, **File > Import > Shoun's ASCII Model importer (.asc)** and select the desired animation file (or armor file), for example `Hum_SmokeHerb_Layer_M01.asc`.  
+    If we now want to play (or edit) an existing animation, we can now load the animation file in .asc on top of our currently loaded model. Just as before, **File > Import > Shoun's ASCII Model Importer (.asc)** and select the desired animation file (or armor file), for example `Hum_SmokeHerb_Layer_M01.asc`.  
 ![type:video](https://www.youtube.com/embed/FDicnSwhv0w)
 
-Gothic characters are modular and you can change their heads on the fly, even during gameplay as seen in this amazing video from my dear friend and colleague Fawkes - [Head changing](https://www.youtube.com/watch?v=2GBmpeyqKIA). Let's add a head so that we can see how the whole body will behave while we are animating. **File > Import > Kerrax ASCII model (.asc)**, navigate to your head model. You will have to decompile it like we did with the body itself. We will import `HUM_HEAD_PONY.ASC`. Please make sure to select the target bone for importing **Bip01 Head**, this will attach the head to the proper bone, just like the engine does it.
+Gothic characters are modular and you can change their heads on the fly, even during gameplay as seen in this amazing video from my dear friend and colleague Fawkes - [Head changing](https://www.youtube.com/watch?v=2GBmpeyqKIA). Let's add a head so that we can see how the whole body will behave while we are animating. **File > Import > Shoun's ASCII Model Importer (.asc)**, navigate to your head model. You will have to decompile it like we did with the body itself. We will import `HUM_HEAD_PONY.ASC`. Please make sure to select the target bone for importing **Bip01 Head**, this will attach the head to the proper bone, just like the engine does it.
 
 ![type:video](https://www.youtube.com/embed/AzotIDHFCSo)
 


### PR DESCRIPTION
I’d like to suggest some rewording in the [Standalone animation doc](https://gothic-modding-community.github.io/gmc/zengin/anims/tutorials/standalone_animation/) to enhance clarity and accuracy:
- reword "How to play or edit animations" note to be a bit more specific and visible (avoid "it" and "this" words)
- update tool name (in latest KrxImpExp it's "Shoun's ASCII Model importer", not Kerrax)