### PR TITLE
Default is German, not English.

### DIFF
--- a/docs/zengin/scripts/extenders/zparserextender/externals/string.md
+++ b/docs/zengin/scripts/extenders/zparserextender/externals/string.md
@@ -53,7 +53,7 @@ Functions to manipulate and format strings.
 
 ## `Str_GetLocalizedString`
 !!! function "`Str_GetLocalizedString`"
-    Returns a string in the current language, otherwise in English.
+    Returns a string in the current language, otherwise in German.
     Arguments MUST be encoded in UTF-8! The result string will be converted to appropriate ANSI string.
 
     ```dae
@@ -71,7 +71,7 @@ Functions to manipulate and format strings.
 
 ## `Str_GetLocalizedStringEx`
 !!! function "`Str_GetLocalizedStringEx`"
-    Returns a string in the current language, otherwise in English.
+    Returns a string in the current language, otherwise in German.
     Offers additional languages
 
     ```dae


### PR DESCRIPTION
It is defined here:
- [zParserExtender | zExternals.cpp](https://github.com/Gratt-5r2/zParserExtender/blob/master/zParserExtender/zExternals.cpp#L1342)
- [zParserExtender | zExternals.cpp](https://github.com/Gratt-5r2/zParserExtender/blob/master/zParserExtender/zExternals.cpp#L1376)